### PR TITLE
Valkyrie 1.0.0

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Get version
         id: version
-        run: echo "version=$(jq -r '.version' valkyrie/package.json)" >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
@@ -34,16 +34,13 @@ jobs:
         with:
           node-version: 24.x
           cache: "pnpm"
-          cache-dependency-path: valkyrie/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        working-directory: valkyrie
         run: pnpm install --frozen-lockfile
       - name: Production build
-        working-directory: valkyrie
-        run: pnpm prod
+        run: pnpm lib:prod
       - name: Pack for npm
-        working-directory: valkyrie
-        run: pnpm pack
+        run: pnpm --dir valkyrie pack
       - name: Package icons
         working-directory: valkyrie/icons
         run: zip -r ../../valkyrie-${{ steps.version.outputs.version }}-icons.zip . -i "*.svg"
@@ -59,9 +56,6 @@ jobs:
   docs_check:
     name: Docs linting and formatting
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -74,13 +68,13 @@ jobs:
         with:
           node-version: 24.x
           cache: "pnpm"
-          cache-dependency-path: docs/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Check formatting
-        run: pnpm format
+        run: pnpm --filter valkyrie-docs format
       - name: Lint
-        run: pnpm lint
+        run: pnpm --filter valkyrie-docs lint
 
   deploy-docs:
     name: Deploy to GitHub Pages
@@ -89,9 +83,6 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -108,11 +99,11 @@ jobs:
         with:
           node-version: 24.x
           cache: "pnpm"
-          cache-dependency-path: docs/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
       - name: Build
-        run: pnpm build
+        run: pnpm docs:build
       - name: Setup Pages
         uses: actions/configure-pages@v5
       - name: Upload artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v6
       - name: Get version
         id: version
-        run: echo "version=$(jq -r '.version' valkyrie/package.json)" >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
       - name: Set up pnpm
         uses: pnpm/action-setup@v5
         with:
@@ -36,16 +36,13 @@ jobs:
         with:
           node-version: 24.x
           cache: "pnpm"
-          cache-dependency-path: valkyrie/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
       - name: Install dependencies
-        working-directory: valkyrie
         run: pnpm install --frozen-lockfile
       - name: Production build
-        working-directory: valkyrie
-        run: pnpm prod
+        run: pnpm lib:prod
       - name: Pack for npm
-        working-directory: valkyrie
-        run: pnpm pack
+        run: pnpm --dir valkyrie pack
       - name: Package icons
         working-directory: valkyrie/icons
         run: zip -r ../../valkyrie-${{ steps.version.outputs.version }}-icons.zip . -i "*.svg"


### PR DESCRIPTION
Welcome to Valkyrie 1.0.0. This is the first stable release of our iconography. Valkyrie 1.x will function as the iconography for Sippy v3.x. Valkyrie 1.0 is practically the same as 1.0 RC2.

## Changes

- 5412b77 b5c59b8 Dependency updates.
- 4f25a01 bb64d27 Update the repository structure to use some of the pnpm workspace functions as a monorepository.