### PR TITLE
Valkyrie 1.0.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valkyrie-docs",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "homepage": "https://sippy-platform.github.io/valkyrie",
   "type": "module",

--- a/docs/src/app/Docs/pages/Changelog.tsx
+++ b/docs/src/app/Docs/pages/Changelog.tsx
@@ -4,6 +4,13 @@ export default function Changelog() {
   return (
     <div className="flex flex-col gap-4">
       <Release
+        name="Valkyrie 1.0.1"
+        version="1.0.1"
+        date="7 July 2026"
+        changed={["Adds the Readme to the package published on the npm registry."]}
+        fixed={["Fixes an error that prevented the documentation from publishing."]}
+      />
+      <Release
         name="Valkyrie 1.0.0"
         version="1.0.0"
         date="7 July 2026"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valkyrie-monorepo",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "build": "pnpm -r build",

--- a/valkyrie/package.json
+++ b/valkyrie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/valkyrie",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The iconography of Sippy.",
   "keywords": [
     "iconography",


### PR DESCRIPTION
Valkyrie 1.0.1 is a minor update. For all intents and purposes, it is the exact same as 1.0.0.

## Changes

- 8dfb03c Adds the readme to the npm package published on the registry.

## Bug fixes

- bec3600 Fixes a linting error that prevented the documentation from publishing.