### PR TITLE
Valkyrie 2.0 alpha 1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valkyrie-docs",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.1",
   "private": true,
   "homepage": "https://sippy-platform.github.io/valkyrie",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "valkyrie-monorepo",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.1",
   "private": true,
   "scripts": {
     "build": "pnpm -r build",

--- a/valkyrie/package.json
+++ b/valkyrie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sippy-platform/valkyrie",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.1",
   "description": "The iconography of Sippy.",
   "keywords": [
     "iconography",


### PR DESCRIPTION
Valkyrie 2.0 alpha 1 is our first preview release for the next major version of Valkyrie. With this update, we're bringing an updated design language to our icons.

## New icons

- `backspace`
- `circle-radio`
- `expand-rectangle`
- `music-list`
- `phone-arrow-bounce-left`
- `phone-arrow-bounce-right`
- `phone-arrow-right`
- `phone-hangup`

## Updated icons

This represents a first batch of icons that is getting a design update to match the new design language. More icons will follow in the following alpha releases.

- `building`
- `calendar-arrow-to-day`
- `calendar-clock`
- `calendar-day`
- `calendar-range-clock`
- `calendar-range`
- `calendar-stars`
- `calendar-week`
- `calendar`
- `chalkboard-person`
- `city`
- `compare`
- `copy`
- `diagram`
- `diamonds`
- `display`
- `door`
- `pen-to-square`
- `phone-arrow-bounce-right`
- `phone-arrow-down-left-prohibited`
- `phone-arrow-down-left`
- `phone-arrow-up-right-prohibited`
- `phone-arrow-up-right`
- `phone-clock`
- `phone-gear`
- `phone-hangup`
- `phone-list`
- `phone-volume`
- `phone-xmark`
- `phone`
